### PR TITLE
Preventive removal of the apache .pid file needed for restarting an existing container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+rm /run/apache2/apache2.pid # in case the server has crashed and we want to restart the container, the pid file must be removed
 chown www-data:www-data /app -R
 source /etc/apache2/envvars
 tail -F /var/log/apache2/* &

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-rm /run/apache2/apache2.pid # in case the server has crashed and we want to restart the container, the pid file must be removed
+rm /run/apache2/apache2.pid # in case the server had crashed and we want to restart the container, the pid file must be removed
 chown www-data:www-data /app -R
 source /etc/apache2/envvars
 tail -F /var/log/apache2/* &

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-rm /run/apache2/apache2.pid # in case the server had crashed and we want to restart the container, the pid file must be removed
+# in case the server had crashed and we want to restart the container, the pid file must be removed; we suppress the error message, if the pid file is not present:
+rm /run/apache2/apache2.pid 2> /dev/null
 chown www-data:www-data /app -R
 source /etc/apache2/envvars
 tail -F /var/log/apache2/* &


### PR DESCRIPTION
Hi Brian,
thanks a lot for sharing your blog https://www.brianchristner.io/how-to-automate-docker-builds-end-to-end/. It is a very good step by step introduction to the topic.

I was following your instructions using a local Tutum node (following both variants described in https://github.com/tutumcloud/node). It worked well at first, but then I have realized that Tutum has a problem with restarting the containers, once they had been stopped non-gracefully (e.g. because of a reboot of my notebook hosting the Tutum node). This is, because a .pid file is not removed, if the container is stopped non-gracefully and I got the error like "httpd dead but pid file exists", I believe.

In /run.sh, I have added a line to remove the pid file in order to mitigate the problem. After that change, Tutum is able to restart the container with no problem.
Best regards,
Oliver
